### PR TITLE
fix isset call with chain node argument

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -460,6 +460,20 @@ func TestEvalBuiltinExpression(t *testing.T) {
 	RunJetTest(t, data, nil, "LenExpression_1", `{{len("111")}}`, "3")
 	RunJetTest(t, data, nil, "LenExpression_2", `{{isset(data)?len(data):0}}`, "0")
 	RunJetTest(t, data, []string{"", "", "", ""}, "LenExpression_3", `{{len(.)}}`, "4")
+	data.Set(
+		"foo", map[string]interface{}{
+			"asd": map[string]string{
+				"bar": "baz",
+			},
+		},
+	)
+	RunJetTest(t, data, nil, "IsSetExpression_1", `{{isset(foo)}}`, "true")
+	RunJetTest(t, data, nil, "IsSetExpression_2", `{{isset(foo.asd)}}`, "true")
+	RunJetTest(t, data, nil, "IsSetExpression_3", `{{isset(foo.asd.bar)}}`, "true")
+	RunJetTest(t, data, nil, "IsSetExpression_4", `{{isset(asd)}}`, "false")
+	RunJetTest(t, data, nil, "IsSetExpression_5", `{{isset(foo.bar)}}`, "false")
+	RunJetTest(t, data, nil, "IsSetExpression_6", `{{isset(foo.asd.foo)}}`, "false")
+	RunJetTest(t, data, nil, "IsSetExpression_7", `{{isset(foo.asd.bar.xyz)}}`, "false")
 }
 
 func TestEvalAutoescape(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug in how isset() evaluated field access expressions: because of variable shadowing in a loop (`value := getFieldOrMethodValue(node.Field[i], value)`, line 725 of eval.go), all fields were accessed on the base instead of the preceding field. This meant accessing a first-level field worked as expected, but a second-level field only worked when a field with the same name also happened to exist on the base of the access expression.

Similar code without this bug existed in evalBaseExpressionGroup(). To prevent the two implementations from diverging, the code was moved into a new evalFieldAccessExpression() function. In isSet(), the error is ignored so as to not stop template execution when visiting a non-existent field.

The test "IsSetExpression_3" added to eval_test.go failed before this fix.